### PR TITLE
Return error state on JSON parse failure

### DIFF
--- a/moai/yoda.py
+++ b/moai/yoda.py
@@ -24,7 +24,7 @@ class YodaContent(object):
         except Exception:
             log = get_moai_log()
             log.warning("Could not load JSON metadata file: {}".format(path))
-            return
+            return False
 
 	    # Modified and id are required for the system to operate
         persistent_identifier_datapackage = dictJsonData['System']['Persistent_Identifier_Datapackage']['Identifier']


### PR DESCRIPTION
Return False if JSON file can't be parsed, so that
update_moai knows that it should ignore this file.
Otherwise update_moai would try to update the database
even though parsing the JSON file has failed, which results in
more errors.