### PR TITLE
YDA-5145 Handle missing metadata gracefully

### DIFF
--- a/moai/metadata/datacite.py
+++ b/moai/metadata/datacite.py
@@ -1,5 +1,6 @@
 from lxml.builder import ElementMaker
 
+from moai.utils import get_moai_log
 
 XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'
 XML_NS = 'https://www.w3.org/TR/xml-names/'
@@ -30,9 +31,13 @@ class DataCite(object):
 
     def __call__(self, element, metadata):
         try:
-            data = metadata.record['metadata']['metadata']
-        except BaseException:
-            pass
+            if 'metadata' in metadata.record['metadata']:
+                data = metadata.record['metadata']['metadata']
+            else:
+                data = metadata.record['metadata']
+        except KeyError:
+            get_moai_log().error("Could not find metadata for " + str(metadata.record))
+            return
 
         # TODO: is deze nog nodig?
         DATACITE = ElementMaker(namespace=self.ns['datacite'],

--- a/moai/metadata/oaidc.py
+++ b/moai/metadata/oaidc.py
@@ -1,6 +1,8 @@
 
 from lxml.builder import ElementMaker
 
+from moai.utils import get_moai_log
+
 XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'
 
 
@@ -30,8 +32,14 @@ class OAIDC(object):
 
     def __call__(self, element, metadata):
 
-        # data = metadata.record
-        data = metadata.record['metadata']
+        try:
+            if 'metadata' in metadata.record['metadata']:
+                data = metadata.record['metadata']['metadata']
+            else:
+                data = metadata.record['metadata']
+        except KeyError:
+            get_moai_log().error("Could not find metadata for " + str(metadata.record))
+            return
 
         OAI_DC = ElementMaker(namespace=self.ns['oai_dc'],
                               nsmap=self.ns)


### PR DESCRIPTION
If metadata is missing for a record, log an error message and continue, so that ListRecords still works if there is a record with missing metadata. Admins can then see in the MOAI log which record is causing a problem.