### PR TITLE
YDA-5568:  fix contributors oaidc

### DIFF
--- a/moai/metadata/oaidc.py
+++ b/moai/metadata/oaidc.py
@@ -176,7 +176,7 @@ class OAIDC(object):
             if not isinstance(con_list, list):
                 con_list = [con_list]
 
-            for dccon in creator_list:
+            for dccon in con_list:
                 name = dccon['Name']['Given_Name'] + ' ' + dccon['Name']['Family_Name']
 
                 affiliation_list = dccon['Affiliation']


### PR DESCRIPTION
When using the OAI_DC format, MOAI overwrote the contributor entries with creator entries.