### PR TITLE
YDA-6853: fix missing author datacite format

### DIFF
--- a/moai/metadata/datacite.py
+++ b/moai/metadata/datacite.py
@@ -94,7 +94,7 @@ class DataCite(object):
                     else:
                         creator.append(NONE.affiliation(affiliation))
 
-                idf_list = dccreator['Person_Identifier']
+                idf_list = dccreator.get('Person_Identifier', [])
                 if not isinstance(idf_list, list):
                     idf_list = [idf_list]
                 for identifier in idf_list:
@@ -233,7 +233,7 @@ class DataCite(object):
                     else:
                         contributor.append(NONE.affiliation(affiliation))
 
-                idf_list = dccontributor['Person_Identifier']
+                idf_list = dccontributor.get('Person_Identifier', [])
                 if not isinstance(idf_list, list):
                     idf_list = [idf_list]
                 for identifier in idf_list:
@@ -270,7 +270,7 @@ class DataCite(object):
                         else:
                             contributor.append(NONE.affiliation(affiliation))
 
-                    idf_list = dccontributor['Person_Identifier']
+                    idf_list = dccontributor.get('Person_Identifier', [])
                     if not isinstance(idf_list, list):
                         idf_list = [idf_list]
                     for identifier in idf_list:

--- a/moai/tests/server_datacite.py
+++ b/moai/tests/server_datacite.py
@@ -41,3 +41,5 @@ class ServerDataciteTest(ServerTest):
         self.assertEqual(xpath.string('//datacite:identifier'), '10.00012/UU01-9SYIHN')
         self.assertEqual(xpath.string('//datacite:language'), 'en')
         self.assertEqual(xpath.string('//datacite:rights'), 'Creative Commons Attribution 4.0 International Public License')
+        self.assertEqual(xpath.string('//datacite:creatorName'), 'A B')
+        self.assertEqual(xpath.string('//datacite:affiliation'), 'Academic Center for Dentistry Amsterdam')


### PR DESCRIPTION
Ensure that creators, contributors and contact persons are returned using Datacite format even if no personal identifier is available, since personal identifiers are optional.